### PR TITLE
Bug: Fixed: Re-rendering Map when Modal Close button was clicked

### DIFF
--- a/client/src/components/Modal/Modal.js
+++ b/client/src/components/Modal/Modal.js
@@ -13,7 +13,7 @@ const ModalOverlay = props => {
         <h2>{props.header}</h2>
       </header>
       {/* Felexible form style block holds "div(body)" and "footer" */}
-      <form onSubmit={props.onSubmit ? props.onSubmit : (e) => e.preventDefault}>
+      <form onSubmit={props.onSubmit ? props.onSubmit : e => e.preventDefault()}>
         <div className={`modal__content ${props.contentClass}`}>
           {props.children}
         </div>


### PR DESCRIPTION
 Bug with the Close button in the Facility details modal.  
It will re-render the map page when the Close button was clicked.
The expected behavior was just to close the modal and back to the map. 

The cause of the bug was because a function was not called.  Parenthesis was missing. 
Adding the parenthesis fixed the bug. 